### PR TITLE
Laravel Reactjs updates

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     ],
     "license": "MIT",
     "require": {
-        "php": "^7.2.5",
+        "php": "^7.2.5||8.0.6",
         "fideloper/proxy": "^4.2",
         "fruitcake/laravel-cors": "^1.0",
         "guzzlehttp/guzzle": "^6.3",

--- a/resources/js/Components/Blog/BlogIndex.js
+++ b/resources/js/Components/Blog/BlogIndex.js
@@ -60,7 +60,7 @@ class BlogIndex extends Component{
                     />
                 );
             }else{
-                BlogListData = <h4>No Data Found !!! <br/><hr/><Link  to="/create-post">Create Your Post</Link></h4>;
+                BlogListData = <h4>No Data Found !!! <br/><hr/><Link  to="/create-blog">Create Your Post</Link></h4>;
             }
         }else{
                 BlogListData = <h4>Loading ...</h4>;

--- a/resources/js/Components/Blog/BlogList/BlogList.js
+++ b/resources/js/Components/Blog/BlogList/BlogList.js
@@ -23,7 +23,7 @@ const BlogList = (props) => {
                 <div className="blog-entry d-md-flex">
                     <img src={props.image} className="img img-2"  alt={"Blog Data"}/>
                     <div className="text text-2 pl-md-4">
-                        <h3 className="mb-2"><a href="#"> {text_truncate(props.title,40)}</a></h3>
+                        <h3 className="mb-2"><Link to={`/post/${props.id}`}>{text_truncate(props.title,40)} </Link></h3>
                         <div className="meta-wrap">
                             <p className="meta">
                                 <span><i className="icon-calendar mr-2"/>{props.date}</span>


### PR DESCRIPTION
added support for PHP 8.0.6
added post link to blog title so the user will be redirected to the article by clicking on the post title
changed changed '/create-post' link to '/create-blog'. '/create-post' is a post request with no page/route attached to it, and gives a '404 page not found error' on click. fixed